### PR TITLE
Menu rework

### DIFF
--- a/components/contextMenu.tsx
+++ b/components/contextMenu.tsx
@@ -7,7 +7,7 @@
 import { findGroupChildrenByChildId, NavContextMenuPatchCallback } from "@api/ContextMenu";
 import { Menu } from "@webpack/common";
 
-import { addChannelToCategory, canMoveChannelInDirection, categories, isPinned, moveChannel, removeChannelFromCategory } from "../data";
+import { moveChannelToCategory, canMoveChannelInDirection, categories, isPinned, moveChannel, removeChannelFromCategory } from "../data";
 import { forceUpdate, settings } from "../index";
 import { openCategoryModal } from "./CreateCategoryModal";
 
@@ -17,14 +17,14 @@ function PinMenuItem(channelId: string) {
     return (
         <Menu.MenuItem
             id="better-pin-dm"
-            label="Pin DMs"
+            label="Move DM to category"
         >
 
-            {!pinned && (
+            {(
                 <>
                     <Menu.MenuItem
                         id="add-category"
-                        label="Add Category"
+                        label="New category"
                         color="brand"
                         action={() => openCategoryModal(null, channelId)}
                     />
@@ -35,19 +35,21 @@ function PinMenuItem(channelId: string) {
                             <Menu.MenuItem
                                 id={`pin-category-${category.name}`}
                                 label={category.name}
-                                action={() => addChannelToCategory(channelId, category.id).then(() => forceUpdate())}
+                                disabled={category.channels.includes(channelId)}
+                                action={() => moveChannelToCategory(channelId, category.id).then(() => forceUpdate())}
                             />
                         ))
                     }
                 </>
             )}
 
-            {pinned && (
+            {(
                 <>
                     <Menu.MenuItem
                         id="unpin-dm"
                         label="Unpin DM"
                         color="danger"
+                        disabled={!pinned}
                         action={() => removeChannelFromCategory(channelId).then(() => forceUpdate())}
                     />
 

--- a/components/contextMenu.tsx
+++ b/components/contextMenu.tsx
@@ -7,7 +7,7 @@
 import { findGroupChildrenByChildId, NavContextMenuPatchCallback } from "@api/ContextMenu";
 import { Menu } from "@webpack/common";
 
-import { moveChannelToCategory, canMoveChannelInDirection, categories, isPinned, moveChannel, removeChannelFromCategory } from "../data";
+import { addChannelToCategory, canMoveChannelInDirection, categories, isPinned, moveChannel, removeChannelFromCategory } from "../data";
 import { forceUpdate, settings } from "../index";
 import { openCategoryModal } from "./CreateCategoryModal";
 
@@ -20,8 +20,7 @@ function PinMenuItem(channelId: string) {
             label="Pin DMs"
         >
 
-            {//!pinned && 
-            (
+            {!pinned && (
                 <>
                     <Menu.MenuItem
                         id="add-category"
@@ -36,7 +35,7 @@ function PinMenuItem(channelId: string) {
                             <Menu.MenuItem
                                 id={`pin-category-${category.name}`}
                                 label={category.name}
-                                action={() => moveChannelToCategory(channelId, category.id).then(() => forceUpdate())}
+                                action={() => addChannelToCategory(channelId, category.id).then(() => forceUpdate())}
                             />
                         ))
                     }

--- a/components/contextMenu.tsx
+++ b/components/contextMenu.tsx
@@ -7,7 +7,7 @@
 import { findGroupChildrenByChildId, NavContextMenuPatchCallback } from "@api/ContextMenu";
 import { Menu } from "@webpack/common";
 
-import { addChannelToCategory, canMoveChannelInDirection, categories, isPinned, moveChannel, removeChannelFromCategory } from "../data";
+import { moveChannelToCategory, canMoveChannelInDirection, categories, isPinned, moveChannel, removeChannelFromCategory } from "../data";
 import { forceUpdate, settings } from "../index";
 import { openCategoryModal } from "./CreateCategoryModal";
 
@@ -20,7 +20,8 @@ function PinMenuItem(channelId: string) {
             label="Pin DMs"
         >
 
-            {!pinned && (
+            {//!pinned && 
+            (
                 <>
                     <Menu.MenuItem
                         id="add-category"
@@ -35,7 +36,7 @@ function PinMenuItem(channelId: string) {
                             <Menu.MenuItem
                                 id={`pin-category-${category.name}`}
                                 label={category.name}
-                                action={() => addChannelToCategory(channelId, category.id).then(() => forceUpdate())}
+                                action={() => moveChannelToCategory(channelId, category.id).then(() => forceUpdate())}
                             />
                         ))
                     }

--- a/data.ts
+++ b/data.ts
@@ -54,6 +54,23 @@ export async function updateCategory(category: Category) {
     saveCats(categories);
 }
 
+export async function moveChannelToCategory(channelId: string, categoryId: string) {    
+    
+    const targetcategory = categories.find(c => c.id === categoryId);
+    if (!targetcategory) return;
+
+    const oldcategory = categories.find(c => c.channels.includes(channelId));
+    if (oldcategory) oldcategory.channels = oldcategory.channels.filter(c => c !== channelId); 
+    // remove channel from old category if it was in one 
+    
+    if (categoryId !== '0') targetcategory.channels.push(channelId);
+    // if categoryId is not 0, add channel to category
+
+    saveCats(categories);
+
+}
+
+/* substituted with an implementation of "moveChannelToCategory";
 export async function addChannelToCategory(channelId: string, categoryId: string) {
     const category = categories.find(c => c.id === categoryId);
     if (!category) return;
@@ -62,8 +79,8 @@ export async function addChannelToCategory(channelId: string, categoryId: string
 
     category.channels.push(channelId);
     saveCats(categories);
-
-}
+} 
+*/
 
 export async function removeChannelFromCategory(channelId: string) {
     const category = categories.find(c => c.channels.includes(channelId));
@@ -85,6 +102,9 @@ export async function removeCategory(categoryId: string) {
 export function isPinned(id: string) {
     return categories.some(c => c.channels.includes(id));
 }
+
+
+
 
 export const canMoveArrayInDirection = (array: any[], index: number, direction: -1 | 1) => {
     const a = array[index];
@@ -114,7 +134,7 @@ function swapElementsInArray(array: any[], index1: number, index2: number) {
     [array[index1], array[index2]] = [array[index2], array[index1]];
 }
 
-// stolen from PinDMs
+
 export async function moveCategory(id: string, direction: -1 | 1) {
     const a = categories.findIndex(m => m.id === id);
     const b = a + direction;

--- a/data.ts
+++ b/data.ts
@@ -54,23 +54,6 @@ export async function updateCategory(category: Category) {
     saveCats(categories);
 }
 
-export async function moveChannelToCategory(channelId: string, categoryId: string) {    
-    
-    const targetcategory = categories.find(c => c.id === categoryId);
-    if (!targetcategory) return;
-
-    const oldcategory = categories.find(c => c.channels.includes(channelId));
-    if (oldcategory) oldcategory.channels = oldcategory.channels.filter(c => c !== channelId); 
-    // remove channel from old category if it was in one 
-    
-    if (categoryId !== '0') targetcategory.channels.push(channelId);
-    // if categoryId is not 0, add channel to category
-
-    saveCats(categories);
-
-}
-
-/* substituted with an implementation of "moveChannelToCategory";
 export async function addChannelToCategory(channelId: string, categoryId: string) {
     const category = categories.find(c => c.id === categoryId);
     if (!category) return;
@@ -79,8 +62,8 @@ export async function addChannelToCategory(channelId: string, categoryId: string
 
     category.channels.push(channelId);
     saveCats(categories);
-} 
-*/
+
+}
 
 export async function removeChannelFromCategory(channelId: string) {
     const category = categories.find(c => c.channels.includes(channelId));
@@ -102,9 +85,6 @@ export async function removeCategory(categoryId: string) {
 export function isPinned(id: string) {
     return categories.some(c => c.channels.includes(id));
 }
-
-
-
 
 export const canMoveArrayInDirection = (array: any[], index: number, direction: -1 | 1) => {
     const a = array[index];
@@ -134,7 +114,7 @@ function swapElementsInArray(array: any[], index1: number, index2: number) {
     [array[index1], array[index2]] = [array[index2], array[index1]];
 }
 
-
+// stolen from PinDMs
 export async function moveCategory(id: string, direction: -1 | 1) {
     const a = categories.findIndex(m => m.id === id);
     const b = a + direction;


### PR DESCRIPTION
Reworking the menu in order to allow users to change the category of pinned DMs without having to unpin them first

![image](https://github.com/Syncxv/betterPinDMs/assets/152296803/4f020990-b59b-4b83-bf42-556334d6d10f)
